### PR TITLE
Add branch associations pages and API

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -29,6 +29,7 @@ import AdminDashboard from "@/pages/admin-dashboard";
 import TournamentManagement from "@/pages/tournament-management";
 import AboutPage from "@/pages/about";
 import BranchesPage from "@/pages/branches";
+import BranchDetailPage from "@/pages/branch-detail";
 import NationalTeamPage from "@/pages/national-team";
 import { useAuth } from "@/hooks/useAuth";
 
@@ -49,6 +50,7 @@ function Router() {
       <Route path="/leagues/:id" component={LeagueDetails} />
       <Route path="/news/:id" component={NewsDetail} />
       <Route path="/news" component={News} />
+      <Route path="/branches/:id" component={BranchDetailPage} />
       <Route path="/branches" component={BranchesPage} />
       <Route path="/national-team" component={NationalTeamPage} />
       <Route path="/about" component={AboutPage} />

--- a/client/src/pages/branch-detail.tsx
+++ b/client/src/pages/branch-detail.tsx
@@ -1,0 +1,59 @@
+import Navigation from "@/components/navigation";
+import PageWithLoading from "@/components/PageWithLoading";
+import { useRoute } from "wouter";
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+
+const BranchDetailPage = () => {
+  const [, params] = useRoute("/branches/:id");
+  const branchId = params?.id;
+
+  const { data: branch, isLoading } = useQuery({
+    queryKey: ["/api/branches", branchId],
+    enabled: !!branchId,
+  });
+
+  return (
+    <PageWithLoading>
+      <Navigation />
+      <div className="container mx-auto px-4 py-8">
+        {isLoading ? (
+          <div className="text-center">Уншиж байна...</div>
+        ) : !branch ? (
+          <div className="text-center">Салбар холбоо олдсонгүй</div>
+        ) : (
+          <Card>
+            <CardHeader>
+              <CardTitle>{branch.location}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {branch.leader && (
+                <div>
+                  <strong>Тэргүүлэгч:</strong> {branch.leader}
+                </div>
+              )}
+              {branch.boardMembers && (
+                <div>
+                  <strong>Тэргүүлэгч гишүүд:</strong> {branch.boardMembers}
+                </div>
+              )}
+              {branch.address && (
+                <div>
+                  <strong>Хаяг:</strong> {branch.address}
+                </div>
+              )}
+              {branch.activities && (
+                <div>
+                  <strong>Үйл ажиллагаа:</strong> {branch.activities}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </PageWithLoading>
+  );
+};
+
+export default BranchDetailPage;
+

--- a/client/src/pages/branches.tsx
+++ b/client/src/pages/branches.tsx
@@ -1,14 +1,215 @@
+import { useState } from "react";
+import { Link } from "wouter";
 import Navigation from "@/components/navigation";
 import PageWithLoading from "@/components/PageWithLoading";
+import { useAuth } from "@/hooks/useAuth";
+import { useToast } from "@/hooks/use-toast";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { queryClient, apiRequest } from "@/lib/queryClient";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { insertBranchSchema } from "@shared/schema";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Plus } from "lucide-react";
+
+type CreateBranchForm = z.infer<typeof insertBranchSchema>;
 
 const BranchesPage = () => {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+
+  const { data: branches = [], isLoading } = useQuery({
+    queryKey: ["/api/branches"],
+  });
+
+  const form = useForm<CreateBranchForm>({
+    resolver: zodResolver(insertBranchSchema),
+    defaultValues: {
+      location: "",
+      leader: "",
+      boardMembers: "",
+      address: "",
+      activities: "",
+    },
+  });
+
+  const createBranchMutation = useMutation({
+    mutationFn: async (data: CreateBranchForm) => {
+      const res = await apiRequest("/api/branches", {
+        method: "POST",
+        body: JSON.stringify(data),
+      });
+      return res.json();
+    },
+    onSuccess: () => {
+      toast({ title: "Амжилттай", description: "Салбар холбоо нэмэгдлээ" });
+      setShowCreateDialog(false);
+      form.reset();
+      queryClient.invalidateQueries({ queryKey: ["/api/branches"] });
+    },
+    onError: () => {
+      toast({
+        title: "Алдаа",
+        description: "Салбар холбоо үүсгэхэд алдаа гарлаа",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const onSubmit = (data: CreateBranchForm) => {
+    createBranchMutation.mutate(data);
+  };
+
   return (
     <PageWithLoading>
       <Navigation />
       <div className="main-bg">
         <div className="container mx-auto px-4 py-8">
-          <h1 className="text-4xl md:text-5xl font-bold text-white mb-4">Салбар холбоод</h1>
-          <p className="text-xl text-gray-300">Монголын ширээний теннисний салбар холбоодын тухай мэдээлэл</p>
+          <div className="flex justify-between items-center mb-6">
+            <div>
+              <h1 className="text-4xl md:text-5xl font-bold text-white mb-2">
+                Салбар холбоод
+              </h1>
+              <p className="text-xl text-gray-300">
+                Монголын ширээний теннисний салбар холбоодын жагсаалт
+              </p>
+            </div>
+            {user && (user as any).role === "admin" && (
+              <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
+                <DialogTrigger asChild>
+                  <Button className="mtta-green text-white hover:bg-mtta-green-dark">
+                    <Plus className="h-4 w-4 mr-2" />
+                    Салбар холбоо нэмэх
+                  </Button>
+                </DialogTrigger>
+                <DialogContent className="max-w-lg">
+                  <DialogHeader>
+                    <DialogTitle>Салбар холбоо нэмэх</DialogTitle>
+                  </DialogHeader>
+                  <Form {...form}>
+                    <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                      <FormField
+                        control={form.control}
+                        name="location"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Байршил</FormLabel>
+                            <FormControl>
+                              <Input {...field} />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                      <FormField
+                        control={form.control}
+                        name="leader"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Тэргүүлэгч</FormLabel>
+                            <FormControl>
+                              <Input {...field} />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                      <FormField
+                        control={form.control}
+                        name="boardMembers"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Тэргүүлэгч гишүүд</FormLabel>
+                            <FormControl>
+                              <Textarea {...field} />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                      <FormField
+                        control={form.control}
+                        name="address"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Хаяг</FormLabel>
+                            <FormControl>
+                              <Input {...field} />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                      <FormField
+                        control={form.control}
+                        name="activities"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Үйл ажиллагаа</FormLabel>
+                            <FormControl>
+                              <Textarea {...field} />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                      <div className="flex justify-end space-x-2 pt-2">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={() => setShowCreateDialog(false)}
+                        >
+                          Цуцлах
+                        </Button>
+                        <Button
+                          type="submit"
+                          className="mtta-green text-white hover:bg-mtta-green-dark"
+                          disabled={createBranchMutation.isPending}
+                        >
+                          {createBranchMutation.isPending
+                            ? "Нэмэж байна..."
+                            : "Хадгалах"}
+                        </Button>
+                      </div>
+                    </form>
+                  </Form>
+                </DialogContent>
+              </Dialog>
+            )}
+          </div>
+
+          {isLoading ? (
+            <div className="text-center text-gray-300">Уншиж байна...</div>
+          ) : branches.length === 0 ? (
+            <p className="text-gray-300">Салбар холбоо бүртгэгдээгүй байна.</p>
+          ) : (
+            <div className="grid md:grid-cols-2 gap-6">
+              {branches.map((branch: any) => (
+                <Link key={branch.id} href={`/branches/${branch.id}`} className="block">
+                  <Card className="hover:shadow-lg transition-shadow">
+                    <CardHeader>
+                      <CardTitle>{branch.location}</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <p className="text-gray-600 text-sm mb-2">
+                        Тэргүүлэгч: {branch.leader}
+                      </p>
+                      <p className="text-gray-600 text-sm line-clamp-2">
+                        {branch.activities}
+                      </p>
+                    </CardContent>
+                  </Card>
+                </Link>
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </PageWithLoading>
@@ -16,3 +217,4 @@ const BranchesPage = () => {
 };
 
 export default BranchesPage;
+

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,7 +2,7 @@ import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { setupAuth, isAuthenticated } from "./replitAuth";
-import { insertPlayerSchema, insertClubSchema, insertTournamentSchema, insertMatchSchema, insertNewsSchema, insertMembershipSchema, insertHomepageSliderSchema, insertSponsorSchema } from "@shared/schema";
+import { insertPlayerSchema, insertClubSchema, insertTournamentSchema, insertMatchSchema, insertNewsSchema, insertMembershipSchema, insertHomepageSliderSchema, insertSponsorSchema, insertBranchSchema } from "@shared/schema";
 import { z } from "zod";
 
 import { ObjectStorageService, ObjectNotFoundError } from "./objectStorage";
@@ -1051,6 +1051,45 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       console.error("Error fetching club:", error);
       res.status(500).json({ message: "Клубын мэдээлэл авахад алдаа гарлаа" });
+    }
+  });
+
+  // Branch routes
+  app.post('/api/branches', requireAuth, async (req: any, res) => {
+    try {
+      const user = await storage.getUser(req.session.userId);
+      if (!user || user.role !== 'admin') {
+        return res.status(403).json({ message: "Зөвхөн админ хэрэглэгч салбар холбоо нэмэх боломжтой" });
+      }
+      const branchData = insertBranchSchema.parse(req.body);
+      const branch = await storage.createBranch(branchData);
+      res.json(branch);
+    } catch (error) {
+      console.error("Error creating branch:", error);
+      res.status(400).json({ message: "Салбар холбоо үүсгэхэд алдаа гарлаа" });
+    }
+  });
+
+  app.get('/api/branches', async (req, res) => {
+    try {
+      const branches = await storage.getAllBranches();
+      res.json(branches);
+    } catch (error) {
+      console.error("Error fetching branches:", error);
+      res.status(500).json({ message: "Салбар холбоодын жагсаалт авахад алдаа гарлаа" });
+    }
+  });
+
+  app.get('/api/branches/:id', async (req, res) => {
+    try {
+      const branch = await storage.getBranch(req.params.id);
+      if (!branch) {
+        return res.status(404).json({ message: "Салбар холбоо олдсонгүй" });
+      }
+      res.json(branch);
+    } catch (error) {
+      console.error("Error fetching branch:", error);
+      res.status(500).json({ message: "Салбар холбооны мэдээлэл авахад алдаа гарлаа" });
     }
   });
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -14,6 +14,7 @@ import {
   tournamentResults,
   homepageSliders,
   sponsors,
+  branches,
   tournamentTeams,
   tournamentTeamPlayers,
   leagueMatches,
@@ -43,6 +44,8 @@ import {
   type InsertHomepageSlider,
   type Sponsor,
   type InsertSponsor,
+  type Branch,
+  type InsertBranch,
   type TournamentTeam,
   type InsertTournamentTeam,
   type TournamentTeamPlayer,
@@ -85,6 +88,11 @@ export interface IStorage {
   createClub(club: InsertClub): Promise<Club>;
   getClubsByOwner(ownerId: string): Promise<Club[]>;
   getAllClubs(): Promise<Club[]>;
+
+  // Branch operations
+  getBranch(id: string): Promise<Branch | undefined>;
+  createBranch(branch: InsertBranch): Promise<Branch>;
+  getAllBranches(): Promise<Branch[]>;
 
   // Tournament operations
   getTournament(id: string): Promise<Tournament | undefined>;
@@ -513,6 +521,21 @@ export class DatabaseStorage implements IStorage {
 
   async getAllClubs(): Promise<Club[]> {
     return await db.select().from(clubs).orderBy(clubs.name);
+  }
+
+  // Branch operations
+  async getBranch(id: string): Promise<Branch | undefined> {
+    const [branch] = await db.select().from(branches).where(eq(branches.id, id));
+    return branch;
+  }
+
+  async createBranch(branchData: InsertBranch): Promise<Branch> {
+    const [branch] = await db.insert(branches).values(branchData).returning();
+    return branch;
+  }
+
+  async getAllBranches(): Promise<Branch[]> {
+    return await db.select().from(branches).orderBy(branches.createdAt);
   }
 
   async updateClub(id: string, clubData: Partial<InsertClub>): Promise<Club | undefined> {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -340,6 +340,17 @@ export const sponsors = pgTable("sponsors", {
   updatedAt: timestamp("updated_at").defaultNow(),
 });
 
+// Branch associations table
+export const branches = pgTable("branches", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  location: varchar("location").notNull(), // Байршил
+  leader: varchar("leader"), // Тэргүүлэгч
+  boardMembers: text("board_members"), // Тэргүүлэгч гишүүд
+  address: text("address"), // Хаяг
+  activities: text("activities"), // Үйл ажиллагаа
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
 // Relations
 export const usersRelations = relations(users, ({ one, many }) => ({
   player: one(players, {
@@ -457,6 +468,11 @@ export const insertSponsorSchema = createInsertSchema(sponsors).omit({
   updatedAt: true,
 });
 
+export const insertBranchSchema = createInsertSchema(branches).omit({
+  id: true,
+  createdAt: true,
+});
+
 export const insertMembershipSchema = createInsertSchema(memberships).omit({
   id: true,
   createdAt: true,
@@ -498,6 +514,8 @@ export type InsertHomepageSlider = z.infer<typeof insertHomepageSliderSchema>;
 export type HomepageSlider = typeof homepageSliders.$inferSelect;
 export type InsertSponsor = z.infer<typeof insertSponsorSchema>;
 export type Sponsor = typeof sponsors.$inferSelect;
+export type InsertBranch = z.infer<typeof insertBranchSchema>;
+export type Branch = typeof branches.$inferSelect;
 export type TournamentParticipant = typeof tournamentParticipants.$inferSelect;
 export type InsertTournamentParticipant = typeof tournamentParticipants.$inferInsert;
 export type TournamentResults = typeof tournamentResults.$inferSelect;


### PR DESCRIPTION
## Summary
- introduce `branches` table and schema with leader, board members, address, location and activities fields
- expose `/api/branches` endpoints and storage helpers for create/list/detail
- build admin form and listings for sub-associations and separate branch detail page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689b15024400832193c4ae0febd336a1