### PR TITLE
Fix branch creation validation

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1056,17 +1056,21 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // Branch routes
   app.post('/api/branches', requireAuth, async (req: any, res) => {
+    const parseResult = insertBranchSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      return res.status(400).json({ message: "Салбар холбооны мэдээлэл буруу байна" });
+    }
+
     try {
       const user = await storage.getUser(req.session.userId);
       if (!user || user.role !== 'admin') {
         return res.status(403).json({ message: "Зөвхөн админ хэрэглэгч салбар холбоо нэмэх боломжтой" });
       }
-      const branchData = insertBranchSchema.parse(req.body);
-      const branch = await storage.createBranch(branchData);
-      res.json(branch);
+      const branch = await storage.createBranch(parseResult.data);
+      res.status(201).json(branch);
     } catch (error) {
       console.error("Error creating branch:", error);
-      res.status(400).json({ message: "Салбар холбоо үүсгэхэд алдаа гарлаа" });
+      res.status(500).json({ message: "Салбар холбоо үүсгэхэд алдаа гарлаа" });
     }
   });
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -468,7 +468,16 @@ export const insertSponsorSchema = createInsertSchema(sponsors).omit({
   updatedAt: true,
 });
 
-export const insertBranchSchema = createInsertSchema(branches).omit({
+// Branch validation schema
+export const insertBranchSchema = createInsertSchema(branches, {
+  // Ensure a non-empty location is provided
+  location: z.string().min(1, "Байршил заавал шаардлагатай"),
+  // Optional text fields
+  leader: z.string().optional(),
+  boardMembers: z.string().optional(),
+  address: z.string().optional(),
+  activities: z.string().optional(),
+}).omit({
   id: true,
   createdAt: true,
 });


### PR DESCRIPTION
## Summary
- require non-empty location and mark optional fields in branch schema
- validate branch data and return 500 on server errors when creating branches

## Testing
- `npm run check` *(fails: Parameter 'city' implicitly has an 'any' type, Property 'membershipStartDate' does not exist on type '{}' ...)*

------
https://chatgpt.com/codex/tasks/task_e_689b181905b4832191421a747d9c4cc1