### PR TITLE
Add federation members management

### DIFF
--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -50,7 +50,7 @@ export default function Navigation() {
             { href: "/about#history", label: "Танилцуулга" },
             { href: "/about#goals", label: "Бидний зорилго" },
             { href: "/about#management", label: "Түүхэн замнал" },
-            { href: "/about#leadership", label: "Захирлуудын зөвлөл" },
+            { href: "/about#members", label: "Холбооны гишүүд" },
           ],
         },
         { href: "/branches", label: "Салбар холбоод" },

--- a/client/src/pages/about.tsx
+++ b/client/src/pages/about.tsx
@@ -7,13 +7,59 @@ import { History, Target, Users, Award } from "lucide-react";
 import Navigation from "@/components/navigation";
 import PageWithLoading from "@/components/PageWithLoading";
 
+const MembersList: React.FC = () => {
+  const [members, setMembers] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchMembers = async () => {
+      try {
+        const res = await fetch('/api/federation-members');
+        const data = await res.json();
+        setMembers(Array.isArray(data) ? data : []);
+      } catch (e) {
+        console.error('Failed to load members', e);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchMembers();
+  }, []);
+
+  if (loading) {
+    return <div>Ачааллаж байна...</div>;
+  }
+
+  if (!members.length) {
+    return <div>Гишүүн олдсонгүй</div>;
+  }
+
+  return (
+    <div className="grid md:grid-cols-2 gap-6">
+      {members.map((member) => (
+        <div key={member.id} className="bg-gray-800 p-6 rounded-lg text-center">
+          {member.imageUrl && (
+            <img
+              src={member.imageUrl}
+              alt={member.name}
+              className="w-24 h-24 rounded-full mx-auto mb-3 object-cover"
+            />
+          )}
+          <h3 className="text-xl font-semibold text-white">{member.name}</h3>
+          <p className="text-green-400">{member.position}</p>
+        </div>
+      ))}
+    </div>
+  );
+};
+
 const AboutPage = () => {
   const [activeTab, setActiveTab] = useState("history");
 
   // Handle URL hash changes to switch tabs
   useEffect(() => {
     const hash = window.location.hash.replace('#', '');
-    if (hash && ['history', 'goals', 'management', 'leadership'].includes(hash)) {
+    if (hash && ['history', 'goals', 'management', 'members'].includes(hash)) {
       setActiveTab(hash);
     }
   }, []);
@@ -68,13 +114,13 @@ const AboutPage = () => {
                 <span className="hidden sm:inline">Түүхэн замнал</span>
                 <span className="sm:hidden">Түүх</span>
               </TabsTrigger>
-              <TabsTrigger 
-                value="leadership" 
+              <TabsTrigger
+                value="members"
                 className="data-[state=active]:bg-green-600 data-[state=active]:text-white text-gray-300 text-xs md:text-sm px-1 md:px-3"
               >
                 <Award className="w-3 h-3 md:w-4 md:h-4 mr-1 md:mr-2" />
-                <span className="hidden sm:inline">Захирлуудын зөвлөл</span>
-                <span className="sm:hidden">Зөвлөл</span>
+                <span className="hidden sm:inline">Холбооны гишүүд</span>
+                <span className="sm:hidden">Гишүүд</span>
               </TabsTrigger>
             </TabsList>
 
@@ -269,110 +315,20 @@ const AboutPage = () => {
               </Card>
             </TabsContent>
 
-            {/* Leadership Tab */}
-            <TabsContent value="leadership" id="leadership">
+            {/* Members Tab */}
+            <TabsContent value="members" id="members">
               <Card className="card-dark">
                 <CardHeader>
                   <CardTitle className="text-2xl text-white flex items-center">
                     <Award className="w-6 h-6 mr-3 text-green-400" />
-                    Захирлуудын зөвлөл
+                    Холбооны гишүүд
                   </CardTitle>
                   <CardDescription className="text-gray-300">
-                    Холбооны удирдлагын бүрэлдэхүүн болон үүрэг хариуцлага
+                    Холбоонд харьяалагдах гишүүдийн мэдээлэл
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="text-gray-300">
-                  <div className="grid md:grid-cols-2 gap-6">
-                    <div className="bg-gray-800 p-6 rounded-lg">
-                      <div className="text-center mb-4">
-                        <div className="w-20 h-20 bg-green-600 rounded-full mx-auto mb-3 flex items-center justify-center">
-                          <Users className="w-8 h-8 text-white" />
-                        </div>
-                        <h3 className="text-xl font-semibold text-white">Б.Болдбаатар</h3>
-                        <p className="text-green-400">Ерөнхий дарга</p>
-                      </div>
-                      <ul className="space-y-2 text-sm">
-                        <li>• Холбооны ерөнхий удирдлага</li>
-                        <li>• Стратегийн чиглэл тодорхойлолт</li>
-                        <li>• Олон улсын харилцаа</li>
-                      </ul>
-                    </div>
-
-                    <div className="bg-gray-800 p-6 rounded-lg">
-                      <div className="text-center mb-4">
-                        <div className="w-20 h-20 bg-green-600 rounded-full mx-auto mb-3 flex items-center justify-center">
-                          <Target className="w-8 h-8 text-white" />
-                        </div>
-                        <h3 className="text-xl font-semibold text-white">Г.Ганбаатар</h3>
-                        <p className="text-green-400">Гүйцэтгэх захирал</p>
-                      </div>
-                      <ul className="space-y-2 text-sm">
-                        <li>• Өдөр тутмын үйл ажиллагаа</li>
-                        <li>• Тэмцээн зохион байгуулалт</li>
-                        <li>• Клубуудтай хамтын ажиллагаа</li>
-                      </ul>
-                    </div>
-
-                    <div className="bg-gray-800 p-6 rounded-lg">
-                      <div className="text-center mb-4">
-                        <div className="w-20 h-20 bg-green-600 rounded-full mx-auto mb-3 flex items-center justify-center">
-                          <History className="w-8 h-8 text-white" />
-                        </div>
-                        <h3 className="text-xl font-semibold text-white">С.Сайханбилэг</h3>
-                        <p className="text-green-400">Дэд дарга</p>
-                      </div>
-                      <ul className="space-y-2 text-sm">
-                        <li>• Тамирчдын хөгжлийн хөтөлбөр</li>
-                        <li>• Дасгалжуулагчдын сургалт</li>
-                        <li>• Техникийн дэмжлэг</li>
-                      </ul>
-                    </div>
-
-                    <div className="bg-gray-800 p-6 rounded-lg">
-                      <div className="text-center mb-4">
-                        <div className="w-20 h-20 bg-green-600 rounded-full mx-auto mb-3 flex items-center justify-center">
-                          <Award className="w-8 h-8 text-white" />
-                        </div>
-                        <h3 className="text-xl font-semibold text-white">Д.Долгорсүрэн</h3>
-                        <p className="text-green-400">Нарийн бичгийн дарга</p>
-                      </div>
-                      <ul className="space-y-2 text-sm">
-                        <li>• Холбооны албан бичиг</li>
-                        <li>• Гишүүдийн бүртгэл</li>
-                        <li>• Мэдээллийн удирдлага</li>
-                      </ul>
-                    </div>
-                  </div>
-
-                  <div className="mt-8 bg-gray-800 p-6 rounded-lg">
-                    <h3 className="text-xl font-semibold text-white mb-4">Зөвлөлийн гишүүд</h3>
-                    <div className="grid md:grid-cols-3 gap-4 text-sm">
-                      <div>
-                        <h4 className="font-semibold text-green-400 mb-2">Техникийн хэсэг</h4>
-                        <ul className="space-y-1">
-                          <li>• Б.Мөнхбат - Ахлах дасгалжуулагч</li>
-                          <li>• Т.Түмэнжаргал - Шүүгч</li>
-                          <li>• Ө.Одгэрэл - Техникийн зөвлөх</li>
-                        </ul>
-                      </div>
-                      <div>
-                        <h4 className="font-semibold text-green-400 mb-2">Удирдлагын хэсэг</h4>
-                        <ul className="space-y-1">
-                          <li>• Ж.Жавхлан - Санхүүгийн захирал</li>
-                          <li>• Р.Равданжав - Хууль зүйч</li>
-                          <li>• Н.Нарантуяа - Хөгжлийн захирал</li>
-                        </ul>
-                      </div>
-                      <div>
-                        <h4 className="font-semibold text-green-400 mb-2">Клубын төлөөлөл</h4>
-                        <ul className="space-y-1">
-                          <li>• П.Пүрэвсүрэн - УБ клуб</li>
-                          <li>• Ч.Чимэддорж - Дархан клуб</li>
-                          <li>• Б.Батбаяр - Эрдэнэт клуб</li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
+                  <MembersList />
                 </CardContent>
               </Card>
             </TabsContent>

--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -86,6 +86,11 @@ export default function AdminDashboard() {
     enabled: selectedTab === 'sponsors'
   });
 
+  const { data: federationMembers, isLoading: federationMembersLoading } = useQuery({
+    queryKey: ['/api/admin/federation-members'],
+    enabled: selectedTab === 'federation-members'
+  });
+
   const { data: branches, isLoading: branchesLoading } = useQuery({
     queryKey: ['/api/branches'],
     enabled: selectedTab === 'branches'
@@ -711,6 +716,62 @@ export default function AdminDashboard() {
                       <Pencil className="w-4 h-4" />
                     </Button>
                     <Button size="sm" variant="destructive" onClick={() => handleDelete(sponsor.id)}>
+                      <Trash2 className="w-4 h-4" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            )) : null}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+
+  const renderFederationMembersTab = () => (
+    <div className="space-y-4">
+      <div className="flex justify-between items-center">
+        <h2 className="text-2xl font-bold">Холбооны гишүүдийн удирдлага</h2>
+        <Button onClick={openCreateDialog}>
+          <Plus className="w-4 h-4 mr-2" />
+          Гишүүн нэмэх
+        </Button>
+      </div>
+
+      {federationMembersLoading ? (
+        <div>Ачааллаж байна...</div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Нэр</TableHead>
+              <TableHead>Албан тушаал</TableHead>
+              <TableHead>Зураг</TableHead>
+              <TableHead>Үйлдэл</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {federationMembers && Array.isArray(federationMembers) ? federationMembers.map((member: any) => (
+              <TableRow key={member.id}>
+                <TableCell>{member.name}</TableCell>
+                <TableCell>{member.position}</TableCell>
+                <TableCell>
+                  {member.imageUrl ? (
+                    <img
+                      src={member.imageUrl}
+                      alt={member.name}
+                      className="w-12 h-12 object-cover rounded-full mx-auto"
+                    />
+                  ) : (
+                    <div className="w-12 h-12 bg-gray-200 rounded-full" />
+                  )}
+                </TableCell>
+                <TableCell>
+                  <div className="flex gap-2">
+                    <Button size="sm" variant="outline" onClick={() => openEditDialog(member)}>
+                      <Pencil className="w-4 h-4" />
+                    </Button>
+                    <Button size="sm" variant="destructive" onClick={() => handleDelete(member.id)}>
                       <Trash2 className="w-4 h-4" />
                     </Button>
                   </div>
@@ -1551,6 +1612,60 @@ export default function AdminDashboard() {
           </>
         );
 
+      case 'federation-members':
+        return (
+          <>
+            <div>
+              <Label htmlFor="name">Нэр</Label>
+              <Input
+                id="name"
+                value={formData.name || ''}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+              />
+            </div>
+            <div>
+              <Label htmlFor="position">Албан тушаал</Label>
+              <Input
+                id="position"
+                value={formData.position || ''}
+                onChange={(e) => setFormData({ ...formData, position: e.target.value })}
+              />
+            </div>
+            <div>
+              <Label className="flex items-center gap-2">
+                <Upload className="w-4 h-4" />
+                Зураг
+              </Label>
+              <div className="space-y-2">
+                <ObjectUploader
+                  maxNumberOfFiles={1}
+                  maxFileSize={5 * 1024 * 1024}
+                  onGetUploadParameters={async () => {
+                    const response = await apiRequest('/api/objects/upload', { method: 'POST' });
+                    const data = await response.json() as { uploadURL: string };
+                    return { method: 'PUT' as const, url: data.uploadURL };
+                  }}
+                  onFileUpload={async (uploadedFileUrl) => {
+                    try {
+                      setFormData({ ...formData, imageUrl: uploadedFileUrl });
+                    } catch (error) {
+                      console.error('Error uploading image:', error);
+                      toast({ title: 'Алдаа', description: 'Зураг хуулахад алдаа гарлаа', variant: 'destructive' });
+                    }
+                  }}
+                />
+                {formData.imageUrl && (
+                  <img
+                    src={formData.imageUrl}
+                    alt="Preview"
+                    className="w-24 h-24 object-cover rounded-full"
+                  />
+                )}
+              </div>
+            </div>
+          </>
+        );
+
       default:
         return <div>Форм боломжгүй</div>;
     }
@@ -1619,6 +1734,10 @@ export default function AdminDashboard() {
             <Zap className="w-4 h-4" />
             Ивээн тэтгэгчид
           </TabsTrigger>
+          <TabsTrigger value="federation-members" className="flex items-center gap-2">
+            <Shield className="w-4 h-4" />
+            Холбооны гишүүд
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="users">
@@ -1677,6 +1796,18 @@ export default function AdminDashboard() {
             </CardHeader>
             <CardContent>
               {renderSponsorsTab()}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="federation-members">
+          <Card>
+            <CardHeader>
+              <CardTitle>Холбооны гишүүдийн удирдлага</CardTitle>
+              <CardDescription>Гишүүдийн мэдээллийг нэмэх, засах, устгах</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {renderFederationMembersTab()}
             </CardContent>
           </Card>
         </TabsContent>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,7 +2,7 @@ import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { setupAuth, isAuthenticated } from "./replitAuth";
-import { insertPlayerSchema, insertClubSchema, insertTournamentSchema, insertMatchSchema, insertNewsSchema, insertMembershipSchema, insertHomepageSliderSchema, insertSponsorSchema, insertBranchSchema } from "@shared/schema";
+import { insertPlayerSchema, insertClubSchema, insertTournamentSchema, insertMatchSchema, insertNewsSchema, insertMembershipSchema, insertHomepageSliderSchema, insertSponsorSchema, insertFederationMemberSchema, insertBranchSchema } from "@shared/schema";
 import { z } from "zod";
 
 import { ObjectStorageService, ObjectNotFoundError } from "./objectStorage";
@@ -2267,6 +2267,65 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       console.error("Error fetching active sliders:", error);
       res.status(500).json({ message: "Идэвхтэй слайдерууд авахад алдаа гарлаа" });
+    }
+  });
+
+  // Federation members routes
+  app.get('/api/federation-members', async (req, res) => {
+    try {
+      const members = await storage.getFederationMembers();
+      res.json(members);
+    } catch (error) {
+      console.error("Error fetching federation members:", error);
+      res.status(500).json({ message: "Холбооны гишүүд авахад алдаа гарлаа" });
+    }
+  });
+
+  app.get('/api/admin/federation-members', requireAuth, isAdminRole, async (req, res) => {
+    try {
+      const members = await storage.getFederationMembers();
+      res.json(members);
+    } catch (error) {
+      console.error("Error fetching federation members:", error);
+      res.status(500).json({ message: "Холбооны гишүүд авахад алдаа гарлаа" });
+    }
+  });
+
+  app.post('/api/admin/federation-members', requireAuth, isAdminRole, async (req, res) => {
+    try {
+      const memberData = insertFederationMemberSchema.parse(req.body);
+      const member = await storage.createFederationMember(memberData);
+      res.status(201).json(member);
+    } catch (error) {
+      console.error("Error creating federation member:", error);
+      res.status(400).json({ message: "Гишүүн үүсгэхэд алдаа гарлаа" });
+    }
+  });
+
+  app.put('/api/admin/federation-members/:id', requireAuth, isAdminRole, async (req, res) => {
+    try {
+      const updateData = insertFederationMemberSchema.partial().parse(req.body);
+      const member = await storage.updateFederationMember(req.params.id, updateData);
+      if (!member) {
+        return res.status(404).json({ message: "Гишүүн олдсонгүй" });
+      }
+      res.json(member);
+    } catch (error) {
+      console.error("Error updating federation member:", error);
+      res.status(400).json({ message: "Гишүүн засварлахад алдаа гарлаа" });
+    }
+  });
+
+  app.delete('/api/admin/federation-members/:id', requireAuth, isAdminRole, async (req, res) => {
+    try {
+      const success = await storage.deleteFederationMember(req.params.id);
+      if (!success) {
+        return res.status(404).json({ message: "Гишүүн олдсонгүй" });
+      }
+      res.json({ message: "Гишүүн амжилттай устгагдлаа" });
+    } catch (error) {
+      console.error("Error deleting federation member:", error);
+      res.status(400).json({ message: "Гишүүн устгахад алдаа гарлаа" });
     }
   });
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -14,6 +14,7 @@ import {
   tournamentResults,
   homepageSliders,
   sponsors,
+  federationMembers,
   branches,
   tournamentTeams,
   tournamentTeamPlayers,
@@ -44,6 +45,8 @@ import {
   type InsertHomepageSlider,
   type Sponsor,
   type InsertSponsor,
+  type FederationMember,
+  type InsertFederationMember,
   type Branch,
   type InsertBranch,
   type TournamentTeam,
@@ -93,6 +96,12 @@ export interface IStorage {
   getBranch(id: string): Promise<Branch | undefined>;
   createBranch(branch: InsertBranch): Promise<Branch>;
   getAllBranches(): Promise<Branch[]>;
+
+  // Federation member operations
+  getFederationMembers(): Promise<FederationMember[]>;
+  createFederationMember(member: InsertFederationMember): Promise<FederationMember>;
+  updateFederationMember(id: string, member: Partial<InsertFederationMember>): Promise<FederationMember | undefined>;
+  deleteFederationMember(id: string): Promise<boolean>;
 
   // Tournament operations
   getTournament(id: string): Promise<Tournament | undefined>;
@@ -536,6 +545,30 @@ export class DatabaseStorage implements IStorage {
 
   async getAllBranches(): Promise<Branch[]> {
     return await db.select().from(branches).orderBy(branches.createdAt);
+  }
+
+  // Federation member operations
+  async getFederationMembers(): Promise<FederationMember[]> {
+    return await db.select().from(federationMembers).orderBy(federationMembers.sortOrder);
+  }
+
+  async createFederationMember(memberData: InsertFederationMember): Promise<FederationMember> {
+    const [member] = await db.insert(federationMembers).values(memberData).returning();
+    return member;
+  }
+
+  async updateFederationMember(id: string, memberData: Partial<InsertFederationMember>): Promise<FederationMember | undefined> {
+    const [member] = await db
+      .update(federationMembers)
+      .set(memberData)
+      .where(eq(federationMembers.id, id))
+      .returning();
+    return member;
+  }
+
+  async deleteFederationMember(id: string): Promise<boolean> {
+    const result = await db.delete(federationMembers).where(eq(federationMembers.id, id));
+    return (result.rowCount ?? 0) > 0;
   }
 
   async updateClub(id: string, clubData: Partial<InsertClub>): Promise<Club | undefined> {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -340,6 +340,16 @@ export const sponsors = pgTable("sponsors", {
   updatedAt: timestamp("updated_at").defaultNow(),
 });
 
+// Federation members table
+export const federationMembers = pgTable("federation_members", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  name: varchar("name").notNull(),
+  position: varchar("position").notNull(),
+  imageUrl: varchar("image_url"),
+  sortOrder: integer("sort_order").default(0),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
 // Branch associations table
 export const branches = pgTable("branches", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
@@ -468,6 +478,11 @@ export const insertSponsorSchema = createInsertSchema(sponsors).omit({
   updatedAt: true,
 });
 
+export const insertFederationMemberSchema = createInsertSchema(federationMembers).omit({
+  id: true,
+  createdAt: true,
+});
+
 // Branch validation schema
 export const insertBranchSchema = createInsertSchema(branches, {
   // Ensure a non-empty location is provided
@@ -523,6 +538,8 @@ export type InsertHomepageSlider = z.infer<typeof insertHomepageSliderSchema>;
 export type HomepageSlider = typeof homepageSliders.$inferSelect;
 export type InsertSponsor = z.infer<typeof insertSponsorSchema>;
 export type Sponsor = typeof sponsors.$inferSelect;
+export type InsertFederationMember = z.infer<typeof insertFederationMemberSchema>;
+export type FederationMember = typeof federationMembers.$inferSelect;
 export type InsertBranch = z.infer<typeof insertBranchSchema>;
 export type Branch = typeof branches.$inferSelect;
 export type TournamentParticipant = typeof tournamentParticipants.$inferSelect;


### PR DESCRIPTION
## Summary
- Rename board of directors section to federation members across navigation and about page
- Introduce federation members table, API routes, and admin dashboard tab for managing members
- Fetch and display federation members dynamically on the about page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Property errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689b201f11508321921cce7bd4270bbc