### PR TITLE
Fix admin tournament creation route

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -66,7 +66,7 @@ function Router() {
           <Route path="/admin/tournaments" component={AdminTournaments} />
           <Route path="/admin/tournament/:id/results" component={AdminTournamentResults} />
           <Route path="/admin/tournament-results" component={AdminTournamentResults} />
-          <Route path="/admin/tournament-create" component={AdminTournamentGenerator} />
+          <Route path="/admin/tournament-create" component={AdminTournamentCreate} />
           <Route path="/admin/tournament/:id/manage" component={TournamentManagement} />
           <Route path="/admin/league/:id/manage" component={TournamentManagement} />
           <Route path="/excel-tournament-demo" component={ExcelTournamentDemo} />


### PR DESCRIPTION
## Summary
- Map /admin/tournament-create route to the tournament creation page instead of the generator

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689b58aa4a408321822ad0a21eaa2220