### PR TITLE
Fix admin tournament creation route and list registration tournaments

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -66,7 +66,7 @@ function Router() {
           <Route path="/admin/tournaments" component={AdminTournaments} />
           <Route path="/admin/tournament/:id/results" component={AdminTournamentResults} />
           <Route path="/admin/tournament-results" component={AdminTournamentResults} />
-          <Route path="/admin/tournament-create" component={AdminTournamentGenerator} />
+          <Route path="/admin/tournament-create" component={AdminTournamentCreate} />
           <Route path="/admin/tournament/:id/manage" component={TournamentManagement} />
           <Route path="/admin/league/:id/manage" component={TournamentManagement} />
           <Route path="/excel-tournament-demo" component={ExcelTournamentDemo} />

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -675,10 +675,15 @@ export class DatabaseStorage implements IStorage {
     return await db
       .select()
       .from(tournaments)
-      .where(and(
-        eq(tournaments.status, "ongoing"),
-        sql`${tournaments.endDate} >= NOW()`
-      ))
+      .where(
+        and(
+          or(
+            eq(tournaments.status, "ongoing"),
+            eq(tournaments.status, "registration")
+          ),
+          sql`${tournaments.endDate} >= NOW()`
+        )
+      )
       .orderBy(tournaments.startDate);
   }
 


### PR DESCRIPTION
## Summary
- Map /admin/tournament-create route to the tournament creation page instead of the generator
- Include tournaments with status "registration" in the active tournaments API query so newly created events appear in listings

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689b58aa4a408321822ad0a21eaa2220