### PR TITLE
Fix tournament generator submit

### DIFF
--- a/client/src/pages/admin-tournament-generator.tsx
+++ b/client/src/pages/admin-tournament-generator.tsx
@@ -136,7 +136,10 @@ export default function AdminTournamentGenerator() {
 
   const createTournament = useMutation({
     mutationFn: async (data: any) => {
-      return apiRequest('POST', '/api/tournaments', data);
+      return apiRequest('/api/tournaments', {
+        method: 'POST',
+        body: JSON.stringify(data),
+      });
     },
     onSuccess: () => {
       toast({


### PR DESCRIPTION
## Summary
- fix tournament creation call to use `apiRequest` correctly so admin generator's "Тэмцээн үүсгэх" button works

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689b786e9e98832197e057e1be9b3743