### PR TITLE
Fix tournament generation API request

### DIFF
--- a/client/src/pages/admin-tournament-create.tsx
+++ b/client/src/pages/admin-tournament-create.tsx
@@ -182,8 +182,8 @@ export default function AdminTournamentCreate() {
     mutationFn: async (data: any) => {
       // Fix: normalize rating values and empty strings
       const normalizeRating = (value?: string) => (value && value !== "none" ? value : undefined);
-      
-      const result = await apiRequest("POST", "/api/tournaments", {
+
+      const payload = {
         ...data,
         richDescription,
         // Fix: send schedule as object, not double-stringified
@@ -194,6 +194,11 @@ export default function AdminTournamentCreate() {
         // Fix: send undefined instead of empty strings for URLs
         backgroundImageUrl: backgroundImageUrl || undefined,
         regulationDocumentUrl: regulationDocumentUrl || undefined,
+      };
+
+      const result = await apiRequest('/api/tournaments', {
+        method: 'POST',
+        body: JSON.stringify(payload),
       });
       return result;
     },

--- a/client/src/pages/admin-tournament-generator.tsx
+++ b/client/src/pages/admin-tournament-generator.tsx
@@ -136,7 +136,6 @@ export default function AdminTournamentGenerator() {
 
   const createTournament = useMutation({
     mutationFn: async (data: any) => {
-<<<<<<< HEAD
       // Fix: schedule is double-stringified
       const payload = {
         ...data,
@@ -148,13 +147,10 @@ export default function AdminTournamentGenerator() {
         backgroundImageUrl: data.backgroundImageUrl === "" ? null : data.backgroundImageUrl,
         regulationDocumentUrl: data.regulationDocumentUrl === "" ? null : data.regulationDocumentUrl,
       };
-      return apiRequest('POST', '/api/tournaments', payload);
-=======
       return apiRequest('/api/tournaments', {
         method: 'POST',
-        body: JSON.stringify(data),
+        body: JSON.stringify(payload),
       });
->>>>>>> origin/replit-agent
     },
     onSuccess: () => {
       toast({


### PR DESCRIPTION
## Summary
- resolve merge conflict in admin tournament generator page
- send tournament creation requests with correct apiRequest signature

## Testing
- `npm run --silent check` *(fails: Property 'playerStats' does not exist on type '{}', and others)*
- `npm test` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689b82762bb883218cbebc5448d21641