### PR TITLE
Add champions page and admin management

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -31,6 +31,7 @@ import AboutPage from "@/pages/about";
 import BranchesPage from "@/pages/branches";
 import BranchDetailPage from "@/pages/branch-detail";
 import NationalTeamPage from "@/pages/national-team";
+import ChampionsPage from "@/pages/champions";
 import { useAuth } from "@/hooks/useAuth";
 
 function Router() {
@@ -53,6 +54,7 @@ function Router() {
       <Route path="/branches/:id" component={BranchDetailPage} />
       <Route path="/branches" component={BranchesPage} />
       <Route path="/national-team" component={NationalTeamPage} />
+      <Route path="/champions" component={ChampionsPage} />
       <Route path="/about" component={AboutPage} />
       <Route path="/" component={Home} />
       {!isLoading && isAuthenticated && (

--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -53,6 +53,7 @@ export default function Navigation() {
             { href: "/about#members", label: "Холбооны гишүүд" },
           ],
         },
+        { href: "/champions", label: "Үе үеийн аваргууд" },
         { href: "/branches", label: "Салбар холбоод" },
         { href: "/national-team", label: "Үндэсний шигшээ" },
       ],

--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -13,7 +13,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { useToast } from "@/hooks/use-toast";
-import { Pencil, Trash2, Plus, Users, Shield, Building, Trophy, Calendar, Newspaper, Images, TrendingUp, Upload, Link as LinkIcon, ArrowLeft, Settings, UserPlus, Play, Zap, X, GitBranch } from "lucide-react";
+import { Pencil, Trash2, Plus, Users, Shield, Building, Trophy, Calendar, Newspaper, Images, TrendingUp, Upload, Link as LinkIcon, ArrowLeft, Settings, UserPlus, Play, Zap, X, GitBranch, Award } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import AdminStatsDashboard from "@/components/admin-stats-dashboard";
@@ -89,6 +89,11 @@ export default function AdminDashboard() {
   const { data: federationMembers, isLoading: federationMembersLoading } = useQuery({
     queryKey: ['/api/admin/federation-members'],
     enabled: selectedTab === 'federation-members'
+  });
+
+  const { data: champions, isLoading: championsLoading } = useQuery({
+    queryKey: ['/api/admin/champions'],
+    enabled: selectedTab === 'champions'
   });
 
   const { data: branches, isLoading: branchesLoading } = useQuery({
@@ -291,6 +296,12 @@ export default function AdminDashboard() {
         boardMembers: '',
         address: '',
         activities: ''
+      };
+    } else if (selectedTab === 'champions') {
+      defaultData = {
+        year: new Date().getFullYear(),
+        name: '',
+        imageUrl: ''
       };
     } else if (selectedTab === 'leagues') {
       // For leagues, provide sensible default dates
@@ -772,6 +783,62 @@ export default function AdminDashboard() {
                       <Pencil className="w-4 h-4" />
                     </Button>
                     <Button size="sm" variant="destructive" onClick={() => handleDelete(member.id)}>
+                      <Trash2 className="w-4 h-4" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            )) : null}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+
+  const renderChampionsTab = () => (
+    <div className="space-y-4">
+      <div className="flex justify-between items-center">
+        <h2 className="text-2xl font-bold">Аваргуудын удирдлага</h2>
+        <Button onClick={openCreateDialog}>
+          <Plus className="w-4 h-4 mr-2" />
+          Аварга нэмэх
+        </Button>
+      </div>
+
+      {championsLoading ? (
+        <div>Ачааллаж байна...</div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Он</TableHead>
+              <TableHead>Нэр</TableHead>
+              <TableHead>Зураг</TableHead>
+              <TableHead>Үйлдэл</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {champions && Array.isArray(champions) ? champions.map((champion: any) => (
+              <TableRow key={champion.id}>
+                <TableCell>{champion.year}</TableCell>
+                <TableCell>{champion.name}</TableCell>
+                <TableCell>
+                  {champion.imageUrl ? (
+                    <img
+                      src={champion.imageUrl}
+                      alt={champion.name}
+                      className="w-12 h-12 object-cover rounded-full mx-auto"
+                    />
+                  ) : (
+                    <div className="w-12 h-12 bg-gray-200 rounded-full" />
+                  )}
+                </TableCell>
+                <TableCell>
+                  <div className="flex gap-2">
+                    <Button size="sm" variant="outline" onClick={() => openEditDialog(champion)}>
+                      <Pencil className="w-4 h-4" />
+                    </Button>
+                    <Button size="sm" variant="destructive" onClick={() => handleDelete(champion.id)}>
                       <Trash2 className="w-4 h-4" />
                     </Button>
                   </div>
@@ -1662,6 +1729,61 @@ export default function AdminDashboard() {
                   />
                 )}
               </div>
+          </div>
+        </>
+        );
+
+      case 'champions':
+        return (
+          <>
+            <div>
+              <Label htmlFor="year">Он</Label>
+              <Input
+                id="year"
+                type="number"
+                value={formData.year || ''}
+                onChange={(e) => setFormData({ ...formData, year: parseInt(e.target.value) })}
+              />
+            </div>
+            <div>
+              <Label htmlFor="name">Нэр</Label>
+              <Input
+                id="name"
+                value={formData.name || ''}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+              />
+            </div>
+            <div>
+              <Label className="flex items-center gap-2">
+                <Upload className="w-4 h-4" />
+                Зураг
+              </Label>
+              <div className="space-y-2">
+                <ObjectUploader
+                  maxNumberOfFiles={1}
+                  maxFileSize={5 * 1024 * 1024}
+                  onGetUploadParameters={async () => {
+                    const response = await apiRequest('/api/objects/upload', { method: 'POST' });
+                    const data = await response.json() as { uploadURL: string };
+                    return { method: 'PUT' as const, url: data.uploadURL };
+                  }}
+                  onFileUpload={async (uploadedFileUrl) => {
+                    try {
+                      setFormData({ ...formData, imageUrl: uploadedFileUrl });
+                    } catch (error) {
+                      console.error('Error uploading image:', error);
+                      toast({ title: 'Алдаа', description: 'Зураг хуулахад алдаа гарлаа', variant: 'destructive' });
+                    }
+                  }}
+                />
+                {formData.imageUrl && (
+                  <img
+                    src={formData.imageUrl}
+                    alt="Preview"
+                    className="w-24 h-24 object-cover rounded-full"
+                  />
+                )}
+              </div>
             </div>
           </>
         );
@@ -1689,7 +1811,7 @@ export default function AdminDashboard() {
       </div>
 
       <Tabs value={selectedTab} onValueChange={setSelectedTab}>
-        <TabsList className="grid w-full grid-cols-11">
+        <TabsList className="grid w-full grid-cols-12">
           <TabsTrigger value="stats" className="flex items-center gap-2">
             <TrendingUp className="w-4 h-4" />
             Статистик
@@ -1737,6 +1859,10 @@ export default function AdminDashboard() {
           <TabsTrigger value="federation-members" className="flex items-center gap-2">
             <Shield className="w-4 h-4" />
             Холбооны гишүүд
+          </TabsTrigger>
+          <TabsTrigger value="champions" className="flex items-center gap-2">
+            <Award className="w-4 h-4" />
+            Аваргууд
           </TabsTrigger>
         </TabsList>
 
@@ -1808,6 +1934,18 @@ export default function AdminDashboard() {
             </CardHeader>
             <CardContent>
               {renderFederationMembersTab()}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="champions">
+          <Card>
+            <CardHeader>
+              <CardTitle>Аваргуудын удирдлага</CardTitle>
+              <CardDescription>Аваргуудын мэдээллийг нэмэх, засах, устгах</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {renderChampionsTab()}
             </CardContent>
           </Card>
         </TabsContent>

--- a/client/src/pages/champions.tsx
+++ b/client/src/pages/champions.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import Navigation from '@/components/navigation';
+import PageWithLoading from '@/components/PageWithLoading';
+
+const ChampionsPage: React.FC = () => {
+  const [champions, setChampions] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchChampions = async () => {
+      try {
+        const res = await fetch('/api/champions');
+        const data = await res.json();
+        setChampions(Array.isArray(data) ? data : []);
+      } catch (e) {
+        console.error('Failed to load champions', e);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchChampions();
+  }, []);
+
+  return (
+    <PageWithLoading>
+      <Navigation />
+      <div className="main-bg">
+        <div className="container mx-auto px-4 py-8">
+          <h1 className="text-4xl md:text-5xl font-bold text-white text-center mb-8 glow-text">
+            Үе үеийн аваргууд
+          </h1>
+          {loading ? (
+            <div>Ачааллаж байна...</div>
+          ) : champions.length ? (
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">
+              {champions.map((champion) => (
+                <div key={champion.id} className="bg-gray-800 p-4 rounded-lg text-center">
+                  {champion.imageUrl && (
+                    <img
+                      src={champion.imageUrl}
+                      alt={champion.name}
+                      className="w-24 h-24 rounded-full mx-auto mb-3 object-cover"
+                    />
+                  )}
+                  <h3 className="text-white font-semibold">{champion.name}</h3>
+                  <p className="text-green-400">{champion.year}</p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div>Аварга олдсонгүй</div>
+          )}
+        </div>
+      </div>
+    </PageWithLoading>
+  );
+};
+
+export default ChampionsPage;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,7 +2,7 @@ import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { setupAuth, isAuthenticated } from "./replitAuth";
-import { insertPlayerSchema, insertClubSchema, insertTournamentSchema, insertMatchSchema, insertNewsSchema, insertMembershipSchema, insertHomepageSliderSchema, insertSponsorSchema, insertFederationMemberSchema, insertBranchSchema } from "@shared/schema";
+import { insertPlayerSchema, insertClubSchema, insertTournamentSchema, insertMatchSchema, insertNewsSchema, insertMembershipSchema, insertHomepageSliderSchema, insertSponsorSchema, insertChampionSchema, insertFederationMemberSchema, insertBranchSchema } from "@shared/schema";
 import { z } from "zod";
 
 import { ObjectStorageService, ObjectNotFoundError } from "./objectStorage";
@@ -2278,6 +2278,65 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       console.error("Error fetching active sliders:", error);
       res.status(500).json({ message: "Идэвхтэй слайдерууд авахад алдаа гарлаа" });
+    }
+  });
+
+  // Champions routes
+  app.get('/api/champions', async (req, res) => {
+    try {
+      const champions = await storage.getChampions();
+      res.json(champions);
+    } catch (error) {
+      console.error("Error fetching champions:", error);
+      res.status(500).json({ message: "Аваргууд авахад алдаа гарлаа" });
+    }
+  });
+
+  app.get('/api/admin/champions', requireAuth, isAdminRole, async (req, res) => {
+    try {
+      const champions = await storage.getChampions();
+      res.json(champions);
+    } catch (error) {
+      console.error("Error fetching champions:", error);
+      res.status(500).json({ message: "Аваргууд авахад алдаа гарлаа" });
+    }
+  });
+
+  app.post('/api/admin/champions', requireAuth, isAdminRole, async (req, res) => {
+    try {
+      const championData = insertChampionSchema.parse(req.body);
+      const champion = await storage.createChampion(championData);
+      res.status(201).json(champion);
+    } catch (error) {
+      console.error("Error creating champion:", error);
+      res.status(400).json({ message: "Аварга үүсгэхэд алдаа гарлаа" });
+    }
+  });
+
+  app.put('/api/admin/champions/:id', requireAuth, isAdminRole, async (req, res) => {
+    try {
+      const updateData = insertChampionSchema.partial().parse(req.body);
+      const champion = await storage.updateChampion(req.params.id, updateData);
+      if (!champion) {
+        return res.status(404).json({ message: "Аварга олдсонгүй" });
+      }
+      res.json(champion);
+    } catch (error) {
+      console.error("Error updating champion:", error);
+      res.status(400).json({ message: "Аварга засварлахад алдаа гарлаа" });
+    }
+  });
+
+  app.delete('/api/admin/champions/:id', requireAuth, isAdminRole, async (req, res) => {
+    try {
+      const success = await storage.deleteChampion(req.params.id);
+      if (!success) {
+        return res.status(404).json({ message: "Аварга олдсонгүй" });
+      }
+      res.json({ message: "Аварга амжилттай устгагдлаа" });
+    } catch (error) {
+      console.error("Error deleting champion:", error);
+      res.status(400).json({ message: "Аварга устгахад алдаа гарлаа" });
     }
   });
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -14,6 +14,7 @@ import {
   tournamentResults,
   homepageSliders,
   sponsors,
+  champions,
   federationMembers,
   branches,
   tournamentTeams,
@@ -45,6 +46,8 @@ import {
   type InsertHomepageSlider,
   type Sponsor,
   type InsertSponsor,
+  type Champion,
+  type InsertChampion,
   type FederationMember,
   type InsertFederationMember,
   type Branch,
@@ -120,6 +123,12 @@ export interface IStorage {
   createFederationMember(member: InsertFederationMember): Promise<FederationMember>;
   updateFederationMember(id: string, member: Partial<InsertFederationMember>): Promise<FederationMember | undefined>;
   deleteFederationMember(id: string): Promise<boolean>;
+
+  // Champion operations
+  getChampions(): Promise<Champion[]>;
+  createChampion(champion: InsertChampion): Promise<Champion>;
+  updateChampion(id: string, champion: Partial<InsertChampion>): Promise<Champion | undefined>;
+  deleteChampion(id: string): Promise<boolean>;
 
   // Tournament operations
   getTournament(id: string): Promise<Tournament | undefined>;
@@ -632,6 +641,30 @@ export class DatabaseStorage implements IStorage {
 
   async deleteFederationMember(id: string): Promise<boolean> {
     const result = await db.delete(federationMembers).where(eq(federationMembers.id, id));
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  // Champion operations
+  async getChampions(): Promise<Champion[]> {
+    return await db.select().from(champions).orderBy(desc(champions.year));
+  }
+
+  async createChampion(championData: InsertChampion): Promise<Champion> {
+    const [champion] = await db.insert(champions).values(championData).returning();
+    return champion;
+  }
+
+  async updateChampion(id: string, championData: Partial<InsertChampion>): Promise<Champion | undefined> {
+    const [champion] = await db
+      .update(champions)
+      .set(championData)
+      .where(eq(champions.id, id))
+      .returning();
+    return champion;
+  }
+
+  async deleteChampion(id: string): Promise<boolean> {
+    const result = await db.delete(champions).where(eq(champions.id, id));
     return (result.rowCount ?? 0) > 0;
   }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -340,6 +340,15 @@ export const sponsors = pgTable("sponsors", {
   updatedAt: timestamp("updated_at").defaultNow(),
 });
 
+// Champions table
+export const champions = pgTable("champions", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  year: integer("year").notNull(),
+  name: varchar("name").notNull(),
+  imageUrl: varchar("image_url"),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
 // Federation members table
 export const federationMembers = pgTable("federation_members", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
@@ -478,6 +487,11 @@ export const insertSponsorSchema = createInsertSchema(sponsors).omit({
   updatedAt: true,
 });
 
+export const insertChampionSchema = createInsertSchema(champions).omit({
+  id: true,
+  createdAt: true,
+});
+
 export const insertFederationMemberSchema = createInsertSchema(federationMembers).omit({
   id: true,
   createdAt: true,
@@ -538,6 +552,8 @@ export type InsertHomepageSlider = z.infer<typeof insertHomepageSliderSchema>;
 export type HomepageSlider = typeof homepageSliders.$inferSelect;
 export type InsertSponsor = z.infer<typeof insertSponsorSchema>;
 export type Sponsor = typeof sponsors.$inferSelect;
+export type InsertChampion = z.infer<typeof insertChampionSchema>;
+export type Champion = typeof champions.$inferSelect;
 export type InsertFederationMember = z.infer<typeof insertFederationMemberSchema>;
 export type FederationMember = typeof federationMembers.$inferSelect;
 export type InsertBranch = z.infer<typeof insertBranchSchema>;


### PR DESCRIPTION
## Summary
- add champions table, API routes, and storage helpers
- expose champions page in navigation and routing
- allow admin to manage champions via dashboard

## Testing
- `npm run check` (fails: Property 'playerStats' does not exist etc.)
- `npm test` (fails: No test files found, exiting with code 1)


------
https://chatgpt.com/codex/tasks/task_e_689b7accc8e08321afdebff9afae4e8c