### PR TITLE
fix: ensure tournament create button displays correctly

### DIFF
--- a/client/src/pages/admin-tournament-create.tsx
+++ b/client/src/pages/admin-tournament-create.tsx
@@ -853,7 +853,7 @@ export default function AdminTournamentCreate() {
                   <div className="space-y-3">
                     <Button
                       type="submit"
-                      className="w-full mtta-green text-white hover:bg-mtta-green-dark"
+                      className="w-full bg-mtta-green text-white hover:bg-mtta-green-dark"
                       disabled={createTournamentMutation.isPending}
                     >
                       <Save className="h-4 w-4 mr-2" />


### PR DESCRIPTION
## Summary
- add missing background color class to tournament creation button

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689b9b97451c8321a5e93d5c0b64227c